### PR TITLE
feat(terraform): add s3 terraform backend

### DIFF
--- a/terraform/cloud/versions.tf
+++ b/terraform/cloud/versions.tf
@@ -1,4 +1,11 @@
 terraform {
+
+  backend "s3" {
+    bucket = "backman-tf-state"
+    key    = "tf.state"
+    region = "eu-north-1"
+  }
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Enforces terraform to use s3 backend instead of running locally. 